### PR TITLE
Fix code scanning alert no. 5: Prototype-polluting assignment

### DIFF
--- a/extension/annotation/annotation.js
+++ b/extension/annotation/annotation.js
@@ -143,7 +143,12 @@ function initializeAnnotation() {
     // Set up message listener for PDF URL
     window.addEventListener("message", (event) => {
         if (event.data.type === "FROM_CONTENT_SCRIPT") {
-            pdfUrl = event.data.pdfUrl;
+            const receivedPdfUrl = event.data.pdfUrl;
+            if (receivedPdfUrl === '__proto__' || receivedPdfUrl === 'constructor' || receivedPdfUrl === 'prototype') {
+                console.error('Invalid PDF URL received:', receivedPdfUrl);
+                return;
+            }
+            pdfUrl = receivedPdfUrl;
             console.log('PDF URL received:', pdfUrl);
         }
     }, false);


### PR DESCRIPTION
Fixes [https://github.com/salcc/Scholar-PDF-Reader-with-Annotations/security/code-scanning/5](https://github.com/salcc/Scholar-PDF-Reader-with-Annotations/security/code-scanning/5)

To fix the problem, we need to ensure that the `pdfUrl` cannot be `__proto__` or any other potentially dangerous key. We can achieve this by adding a validation step before using `pdfUrl` as a key. If the `pdfUrl` is invalid, we should not proceed with the operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
